### PR TITLE
Change to remove syntax warning

### DIFF
--- a/scripts/MDCS.py
+++ b/scripts/MDCS.py
@@ -205,7 +205,7 @@ def main(argc, argv):
         if verMessage is  True:
            log.Message('Installed version is the latest version', logger.Logger.const_general_text) 
         else:
-            if verMessage is not 'Ignore':
+            if verMessage != 'Ignore':
                 log.Message(verMessage, logger.Logger.const_warning_text)
     # ends
     if (os.path.isfile(config) == False):


### PR DESCRIPTION
#121 
Change to remove syntax warning

C:\Image_Mgmt_Workflows\MDCS\Sentinel-2-L2A-AWS\scripts\MDCS.py:208: SyntaxWarning: "is not" with a literal. Did you mean "!="?

  if verMessage is not 'Ignore':