### PR TITLE
Feat: Add Lidar standard commands 

### DIFF
--- a/scripts/master.xml
+++ b/scripts/master.xml
@@ -3,7 +3,7 @@
 	<!-- Support for Dynamic Variable <Name>$xyz$</Name> or <Name>DefaultValue;$xyz$</Name> The variable value can be passed from the command line -->
 	<Name>Name_of_Project</Name>
 	<Command>DefaultCommand</Command>
-	<!-- Commands avaiable CM, AR, CR, SP, BP, AF, CFC, CC, CBMD, ERF, ANCP, APCP, ABA, SMDI, CBA, CCP, CTP, AMDS, AMD, BMDIC, CDA, GEA, CS, BPS, BF, BS, BB, DN, SY, IG, SS, DF, DO, BO, MMDI, DMD, RRFMD, RP, RI, AI, JF, CV, MTC, ETC, STP, SE, EMDG, EMDI, SMDI, CSDD, STS, CRTT, CLT,CCM,BSM,GPC,IFPC,CRA,USD,DEL,BMI,GMA,AMR,CF,UIO,EFACP,GBAR,RR,CPCSLP,TF,CPUDL,DOUDL,COUDL,EFUAIM,CL -->
+	<!-- Commands avaiable CM, AR, CR, SP, BP, AF, CFC, CC, CBMD, ERF, ANCP, APCP, ABA, SMDI, CBA, CCP, CTP, AMDS, AMD, BMDIC, CDA, GEA, CS, BPS, BF, BS, BB, DN, SY, IG, SS, DF, DO, BO, MMDI, DMD, RRFMD, RP, RI, AI, JF, CV, MTC, ETC, STP, SE, EMDG, EMDI, SMDI, CSDD, STS, CRTT, CLT,CCM,BSM,GPC,IFPC,CRA,USD,DEL,BMI,GMA,AMR,CF,UIO,EFACP,GBAR,RR,CPCSLP,TF,CPUDL,DOUDL,COUDL,EFUAIM,CL,EL,CLAS -->
 	<!-- Commands can be combined using the + sign and some commands can be called multiple times, refer to MDCS document for more help -->
 	<ArcGISVersion>
 		<!-- Defines Min Max version required. Eg due to know issue in previsous versions -->
@@ -1025,6 +1025,38 @@
 					<define_coordinate_system>NO_FILES;ALL_FILES;FILES_MISSING_PROJECTION</define_coordinate_system>
 					<in_coordinate_system>#</in_coordinate_system>
 				</ConvertLas>
+						
+		        <!-- EL Extract Las -->
+		        <!-- https://pro.arcgis.com/en/pro-app/latest/tool-reference/3d-analyst/extract-las.htm -->
+				<ExtractLas>
+					<in_las_dataset>#</in_las_dataset>
+					<target_folder>#</target_folder>
+					<extent>#</extent>
+					<boundary>#</boundary>
+					<process_entire_files>PROCESS_EXTENT;PROCESS_ENTIRE_FILES</process_entire_files>
+					<name_suffix>#</name_suffix>
+					<remove_vlr>MAINTAIN_VLR;REMOVE_VLR</remove_vlr>
+					<rearrange_points>MAINTAIN_POINTS;REARRANGE_POINTS</rearrange_points>
+					<compute_stats>COMPUTE_STATS;NO_COMPUTE_STATS</compute_stats>
+					<out_las_dataset>#</out_las_dataset>
+					<compression>SAME_AS_INPUT;NO_COMPRESSION;ZLAS</compression>
+				</ExtractLas>
+						
+		        <!-- CLAS Colorize Las -->
+		        <!-- https://pro.arcgis.com/en/pro-app/latest/tool-reference/3d-analyst/colorize-las.htm -->
+				<ColorizeLAS>
+					<in_las_dataset>#</in_las_dataset>
+					<in_image>#</in_image>
+					<bands>#</bands>
+					<target_folder>#</target_folder>
+					<name_suffix>#</name_suffix>
+					<las_version>1.2;1.3;1.4</las_version>
+					<point_format>2;3;7;8</point_format>
+					<compression>NO_COMPRESSION;ZLAS</compression>
+					<rearrange_points>NO_REARRANGE_POINTS;REARRANGE_POINTS</rearrange_points>
+					<compute_stats>COMPUTE_STATS;NO_COMPUTE_STATS</compute_stats>
+					<out_las_dataset>#</out_las_dataset>
+				</ColorizeLAS>
 		</Processes>
 	</MosaicDataset>
 </Workspace>

--- a/scripts/master.xml
+++ b/scripts/master.xml
@@ -3,7 +3,7 @@
 	<!-- Support for Dynamic Variable <Name>$xyz$</Name> or <Name>DefaultValue;$xyz$</Name> The variable value can be passed from the command line -->
 	<Name>Name_of_Project</Name>
 	<Command>DefaultCommand</Command>
-	<!-- Commands avaiable CM, AR, CR, SP, BP, AF, CFC, CC, CBMD, ERF, ANCP, APCP, ABA, SMDI, CBA, CCP, CTP, AMDS, AMD, BMDIC, CDA, GEA, CS, BPS, BF, BS, BB, DN, SY, IG, SS, DF, DO, BO, MMDI, DMD, RRFMD, RP, RI, AI, JF, CV, MTC, ETC, STP, SE, EMDG, EMDI, SMDI, CSDD, STS, CRTT, CLT,CCM,BSM,GPC,IFPC,CRA,USD,DEL,BMI,GMA,AMR,CF,UIO,EFACP,GBAR,RR,CPCSLP,TF,CPUDL,DOUDL,COUDL,EFUAIM -->
+	<!-- Commands avaiable CM, AR, CR, SP, BP, AF, CFC, CC, CBMD, ERF, ANCP, APCP, ABA, SMDI, CBA, CCP, CTP, AMDS, AMD, BMDIC, CDA, GEA, CS, BPS, BF, BS, BB, DN, SY, IG, SS, DF, DO, BO, MMDI, DMD, RRFMD, RP, RI, AI, JF, CV, MTC, ETC, STP, SE, EMDG, EMDI, SMDI, CSDD, STS, CRTT, CLT,CCM,BSM,GPC,IFPC,CRA,USD,DEL,BMI,GMA,AMR,CF,UIO,EFACP,GBAR,RR,CPCSLP,TF,CPUDL,DOUDL,COUDL,EFUAIM,CL -->
 	<!-- Commands can be combined using the + sign and some commands can be called multiple times, refer to MDCS document for more help -->
 	<ArcGISVersion>
 		<!-- Defines Min Max version required. Eg due to know issue in previsous versions -->
@@ -1011,6 +1011,20 @@
 		          <regularization_method>Right Angles;Right Angles and Diagonals;Any Angles;Circle</regularization_method>
 		          <poly_tolerance>#</poly_tolerance>
 		        </ExtractFeaturesUsingAIModels>
+						
+		        <!-- CL Convert Las -->
+		        <!-- https://pro.arcgis.com/en/pro-app/latest/tool-reference/conversion/convert-las.htm -->
+				<ConvertLas>
+					<in_las>#</in_las>
+					<target_folder>#</target_folder>
+					<file_version>SAME_AS_INPUT;1.0;1.1;1.2;1.3;1.4</file_version>
+					<point_format>0;1;2;3;4;5;6;7;8</point_format>
+					<compression>NO_COMPRESSION;ZLAS;LAZ</compression>
+					<las_options>REARRANGE_POINTS;REMOVE_VLR;REMOVE_EXTRA_BYTES</las_options>
+					<out_las_dataset>#</out_las_dataset>
+					<define_coordinate_system>NO_FILES;ALL_FILES;FILES_MISSING_PROJECTION</define_coordinate_system>
+					<in_coordinate_system>#</in_coordinate_system>
+				</ConvertLas>
 		</Processes>
 	</MosaicDataset>
 </Workspace>

--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -2066,7 +2066,14 @@ class Solutions(Base.Base):
                 'arcpy.geoai.ExtractFeaturesUsingAIModels',
                 index
             )
-
+        elif (com == 'CL'):
+            self.m_log.Message("\t{}:{}".format(self.commands[com]['desc'], self.m_base.m_mdName), self.m_log.const_general_text)
+            return self.__invokeDynamicFn(
+                [],
+                'convertlas',
+                'arcpy.conversion.ConvertLas',
+                index
+            )
         else:
             # The command could be a user defined function externally defined
             # in the module (MDCS_UC.py). Let's invoke it.
@@ -2432,6 +2439,10 @@ class Solutions(Base.Base):
              },
             'EFUAIM':
             {'desc': 'Extract Features Using AI Models',
+             'fnc': executeCommand
+             },
+            'CL':
+            {'desc': 'Convert LAS',
              'fnc': executeCommand
              }
         }

--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -2074,6 +2074,22 @@ class Solutions(Base.Base):
                 'arcpy.conversion.ConvertLas',
                 index
             )
+        elif (com == 'EL'):
+            self.m_log.Message("\t{}:{}".format(self.commands[com]['desc'], self.m_base.m_mdName), self.m_log.const_general_text)
+            return self.__invokeDynamicFn(
+                [],
+                'extractlas',
+                'arcpy.ddd.ExtractLas',
+                index
+            )
+        elif (com == 'CLAS'):
+            self.m_log.Message("\t{}:{}".format(self.commands[com]['desc'], self.m_base.m_mdName), self.m_log.const_general_text)
+            return self.__invokeDynamicFn(
+                [],
+                'colorizelas',
+                'arcpy.ddd.ColorizeLas',
+                index
+            )
         else:
             # The command could be a user defined function externally defined
             # in the module (MDCS_UC.py). Let's invoke it.
@@ -2443,6 +2459,14 @@ class Solutions(Base.Base):
              },
             'CL':
             {'desc': 'Convert LAS',
+             'fnc': executeCommand
+             },
+            'CLAS':
+            {'desc': 'Colorize LAS',
+             'fnc': executeCommand
+             },
+            'EL':
+            {'desc': 'Extract LAS',
              'fnc': executeCommand
              }
         }


### PR DESCRIPTION
Issue -> https://github.com/Esri/mdcs-py/issues/134

This PR adds following standard commands for Lidar:
1. CL (Convert Las)
2. EL (Extract Las)
3. CLAS (Colorize LAS)