### PR TITLE
feat: support indexing in getXMLNode and getXMLNodeValue

### DIFF
--- a/scripts/Base/Base.py
+++ b/scripts/Base/Base.py
@@ -640,18 +640,18 @@ class Base(object):
             return False
         return True
 
-    def getXMLNodeValue(self, doc, nodeName):
+    def getXMLNodeValue(self, doc, nodeName, index=0):
         if (doc is None):
             return ''
         node = doc.getElementsByTagName(nodeName)
 
         if (node is None or
             node.length == 0 or
-            node[0].hasChildNodes() == False or
-                node[0].firstChild.nodeType != Base.NODE_TYPE_TEXT):
+            node[index].hasChildNodes() == False or
+                node[index].firstChild.nodeType != Base.NODE_TYPE_TEXT):
             return ''
 
-        return node[0].firstChild.data
+        return node[index].firstChild.data
 
     def updateART(self, doc, workspace, dataset):
         if (doc is None):
@@ -764,18 +764,18 @@ class Base(object):
                 updateVal = ''.join(revalue)
                 node.firstChild.data = updateVal
 
-    def getXMLNode(self, doc, nodeName):
+    def getXMLNode(self, doc, nodeName, index=0):
         if (doc is None):
             return ''
         node = doc.getElementsByTagName(nodeName)
 
         if (node is None or
             node.length == 0 or
-            node[0].hasChildNodes() == False or
-                node[0].firstChild.nodeType != Base.NODE_TYPE_TEXT):
+            node[index].hasChildNodes() == False or
+                node[index].firstChild.nodeType != Base.NODE_TYPE_TEXT):
             return ''
 
-        return node[0]
+        return node[index]
 
     def foundLockFiles(self, folder_path):
 


### PR DESCRIPTION
Issue -> https://github.com/Esri/mdcs-py/issues/187

This PR adds indexing support to the functions `getXMLNode `and `getXMLNodeValue `in `Base.py` with default being 0-index.

In the MDCS command chain, when the same command is invoked multiple times, command indexing is applied (e.g., `TF0`, `TF1`, etc.) to distinguish between instances. However, the existing implementations of `getXMLNode `and `getXMLNodeValue `only supported the default (0-indexed) command instance.