### PR TITLE
Fix: SolutionsLib - WF should raise error if MTC fails

### DIFF
--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -2794,7 +2794,7 @@ class Solutions(Base.Base):
             if (
                 status
                 == False  # do not continue with any following commands if AR / user defined function commands fail.
-                and (cmd in ["AR", "CM", "CBA", "ABA"] or is_user_cmd)
+                and (cmd in ["AR", "CM", "CBA", "ABA", "MTC"] or is_user_cmd)
             ):
                 if self.on_exit():
                     aryCmds = [self.m_base.EVT_ON_EXIT]


### PR DESCRIPTION
Add MTC to the list of standard commands for which errors raised should stop the workflow. 