### PR TITLE
fix: add accessKey and secretKey for redaction in logs

### DIFF
--- a/scripts/MDCS.py
+++ b/scripts/MDCS.py
@@ -41,7 +41,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 import json
 import shutil
 import uuid
-redacting_patterns = ["token", 'validatingToken']
+redacting_patterns = ["token", "validatingToken", "accessKey", "secretKey"]
 # cli callback ptrs
 g_cli_callback = None
 g_cli_msg_callback = None


### PR DESCRIPTION
Issue -> https://github.com/Esri/mdcs-py/issues/191

Sensitive information for MDCS should be redacted from the logs. Values for `token `and `validatingToken `were being redacted till now. This PR makes change to redact information for `accessKey `and `secretKey `as well.