### PR TITLE
fix: importing log_gptool_result from Base

### DIFF
--- a/scripts/CreateMD/CreateMD.py
+++ b/scripts/CreateMD/CreateMD.py
@@ -90,7 +90,7 @@ class CreateMD(Base.Base):
                 self.product_definition,
                 self.product_band_definitions
             )
-            Base.Base.log_gptool_result(self.log, self.const_general_text, result)
+            Base.log_gptool_result(self.log, self.const_general_text, result)
             return self.m_base._updateResponse(resp, status=True, output=mdPath)
         except Exception as e:
             self.log('Failed!\n{}\n{}'.format(arcpy.GetMessages(), e), self.const_critical_text)

--- a/scripts/CreateMD/CreateMD.py
+++ b/scripts/CreateMD/CreateMD.py
@@ -26,7 +26,7 @@ import sys
 from defusedxml import minidom
 
 import Base
-from Base.Base import log_gptool_result
+from Base import log_gptool_result
 
 class CreateMD(Base.Base):
 

--- a/scripts/CreateMD/CreateMD.py
+++ b/scripts/CreateMD/CreateMD.py
@@ -26,7 +26,6 @@ import sys
 from defusedxml import minidom
 
 import Base
-from Base import log_gptool_result
 
 class CreateMD(Base.Base):
 
@@ -91,7 +90,7 @@ class CreateMD(Base.Base):
                 self.product_definition,
                 self.product_band_definitions
             )
-            log_gptool_result(self.log, self.const_general_text, result)
+            Base.Base.log_gptool_result(self.log, self.const_general_text, result)
             return self.m_base._updateResponse(resp, status=True, output=mdPath)
         except Exception as e:
             self.log('Failed!\n{}\n{}'.format(arcpy.GetMessages(), e), self.const_critical_text)

--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -25,7 +25,7 @@ import sys
 scriptPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(scriptPath, 'Base'))
 import Base
-from Base.Base import log_gptool_result
+from Base import log_gptool_result
 import arcpy
 from defusedxml import minidom
 from string import ascii_letters, digits

--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -1406,7 +1406,7 @@ class Solutions(Base.Base):
                             processKey, 'expression', index, indx), self.getProcessInfoValue(
                             processKey, 'expression_type', index, indx), self.getProcessInfoValue(
                             processKey, 'code_block', index, indx))
-                    Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
+                    Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 except BaseException:
                     self.log(
                         arcpy.GetMessages(),
@@ -1539,7 +1539,7 @@ class Solutions(Base.Base):
                     self.getProcessInfoValue(processKey, 'max_cell_size', index),
                     self.getProcessInfoValue(processKey, 'min_cached_scale', index),
                     self.getProcessInfoValue(processKey, 'max_cached_scale', index))
-                Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
+                Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 try:
                     if os.path.isfile(tileSchemeMtc):
                         cachepath = os.path.join(
@@ -1587,7 +1587,7 @@ class Solutions(Base.Base):
                         processKey, 'storage_format_type', index), self.getProcessInfoValue(
                         processKey, 'scales', index), self.getProcessInfoValue(
                             processKey, 'area_of_interest', index))
-                Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
+                Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 return True
             except BaseException:
                 self.log(arcpy.GetMessages(), self.m_log.const_critical_text)

--- a/scripts/solutionsLib.py
+++ b/scripts/solutionsLib.py
@@ -25,7 +25,6 @@ import sys
 scriptPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(scriptPath, 'Base'))
 import Base
-from Base import log_gptool_result
 import arcpy
 from defusedxml import minidom
 from string import ascii_letters, digits
@@ -1407,7 +1406,7 @@ class Solutions(Base.Base):
                             processKey, 'expression', index, indx), self.getProcessInfoValue(
                             processKey, 'expression_type', index, indx), self.getProcessInfoValue(
                             processKey, 'code_block', index, indx))
-                    log_gptool_result(self.log, self.m_log.const_general_text, result)
+                    Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 except BaseException:
                     self.log(
                         arcpy.GetMessages(),
@@ -1540,7 +1539,7 @@ class Solutions(Base.Base):
                     self.getProcessInfoValue(processKey, 'max_cell_size', index),
                     self.getProcessInfoValue(processKey, 'min_cached_scale', index),
                     self.getProcessInfoValue(processKey, 'max_cached_scale', index))
-                log_gptool_result(self.log, self.m_log.const_general_text, result)
+                Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 try:
                     if os.path.isfile(tileSchemeMtc):
                         cachepath = os.path.join(
@@ -1588,7 +1587,7 @@ class Solutions(Base.Base):
                         processKey, 'storage_format_type', index), self.getProcessInfoValue(
                         processKey, 'scales', index), self.getProcessInfoValue(
                             processKey, 'area_of_interest', index))
-                log_gptool_result(self.log, self.m_log.const_general_text, result)
+                Base.Base.log_gptool_result(self.log, self.m_log.const_general_text, result)
                 return True
             except BaseException:
                 self.log(arcpy.GetMessages(), self.m_log.const_critical_text)


### PR DESCRIPTION
This PR fixes the bug to correctly import `log_gptool_result` from `Base`
https://github.com/Esri/mdcs-py/pull/193